### PR TITLE
Update README with correct --with-zeromq usage

### DIFF
--- a/README
+++ b/README
@@ -10,7 +10,7 @@ To build Debian package run:
 
 $ dpkg-buildpackage -rfakeroot
 
-If your zmq installation is not found by configure you can add this information manually e.g. --with-zeromq=/usr/local/lib.
+If your zmq installation is not found by configure you can add this information manually e.g. --with-zeromq=/usr/local.
  
 You may want to take a look at http://www.zeromq.org/docs:tuning-zeromq for additional hints.
 


### PR DESCRIPTION
I built zeromq locally:

```
zeromq-x.y.z $ ./configure --prefix=$HOME/zeromq; make; make install
```

Then built jzmq according to your README but I had to change the ```--with-zeromq``` directory to point to the parent of the ```lib``` dir to get it build successfully:

```
jzmq-git $ ./configure --prefix=$HOME/jzmq --with-zeromq=$HOME/zeromq
```
